### PR TITLE
Спрятать верхнюю панель чата, которая плохо выглядит на узком экране

### DIFF
--- a/slack-hide-panes.css
+++ b/slack-hide-panes.css
@@ -9,3 +9,7 @@
 .slack-hide-panes .p-workspace--classic-nav .p-workspace__sidebar {
   display: none;
 }
+
+.slack-hide-panes .p-workspace__top_nav {
+  display: none;
+}

--- a/slack-hide-panes.css
+++ b/slack-hide-panes.css
@@ -1,3 +1,7 @@
+.slack-hide-panes .p-workspace--classic-nav {
+  grid-template-rows: min-content 0 auto;
+}
+
 .slack-hide-panes .p-classic_nav .p-classic_nav__team_header {
   display: none;
 }
@@ -7,9 +11,5 @@
 }
 
 .slack-hide-panes .p-workspace--classic-nav .p-workspace__sidebar {
-  display: none;
-}
-
-.slack-hide-panes .p-workspace__top_nav {
   display: none;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9461925/68071192-c38dc480-fd80-11e9-90a9-fc0af1609cdb.png)

Проверил как работает в Хроме